### PR TITLE
Fix to allow some special characters for repo-id

### DIFF
--- a/src/release.lisp
+++ b/src/release.lisp
@@ -133,14 +133,14 @@
              (domain (quri:uri-domain uri)))
         (cond
           ((string= domain "github.com")
-           (let ((repos-id (ppcre:scan-to-strings "/[^/]+/[^/\\.]+" (quri:uri-path uri))))
+           (let ((repos-id (ppcre:scan-to-strings "/[^/]+/[a-zA-Z0-9-_.]+" (quri:uri-path uri))))
              (concatenate 'string
                           "https://github.com"
                           repos-id)))
           ((string= domain "bitbucket.org")
            source-url)
           ((string= domain "gitlab.common-lisp.net")
-           (let ((repos-id (ppcre:scan-to-strings "/[^/]+/[^/\\.]+" (quri:uri-path uri))))
+           (let ((repos-id (ppcre:scan-to-strings "/[^/]+/[a-zA-Z0-9-_.]+" (quri:uri-path uri))))
              (concatenate 'string
                           "http://gitlab.common-lisp.net"
                           repos-id))))))))


### PR DESCRIPTION
## Problem

Some repositories' repo-id is incorrect, so the anchor link is broken.

e.g.)
- http://quickdocs.org/ax.tga/
- http://quickdocs.org/bytecurry.mocks/
## Solution

Make regexp to list whitelisted characters, which contains `.`.
